### PR TITLE
Fix dev deps configuration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,6 +43,7 @@ class AppServiceProvider extends ServiceProvider
 
         if (config('app.debug')) {
             $this->app->register(\Arcanedev\LogViewer\LogViewerServiceProvider::class);
+            $this->app->register(\Arcanedev\LogViewer\Providers\DeferredServicesProvider::class);
             $this->app->register(\PrettyRoutes\ServiceProvider::class);
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
         }

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,10 @@
     "extra": {
         "laravel": {
             "dont-discover": [
-              "sentry/sentry-laravel"
+                "arcanedev/log-viewer",
+                "barryvdh/laravel-ide-helper",
+                "garygreen/pretty-routes",
+                "sentry/sentry-laravel"
             ]
         },
         "hooks": {

--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -1,0 +1,141 @@
+<?php
+
+use Arcanedev\LogViewer\Contracts\Utilities\Filesystem;
+
+return [
+
+    /* -----------------------------------------------------------------
+     |  Log files storage path
+     | -----------------------------------------------------------------
+     */
+
+    'storage-path'  => storage_path('logs'),
+
+    /* -----------------------------------------------------------------
+     |  Log files pattern
+     | -----------------------------------------------------------------
+     */
+
+    'pattern'       => [
+        'prefix'    => Filesystem::PATTERN_PREFIX,    // 'laravel-'
+        'date'      => Filesystem::PATTERN_DATE,      // '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'
+        'extension' => Filesystem::PATTERN_EXTENSION, // '.log'
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Locale
+     | -----------------------------------------------------------------
+     |  Supported locales :
+     |    'auto', 'ar', 'bg', 'de', 'en', 'es', 'et', 'fa', 'fr', 'hu', 'hy', 'id', 'it', 'ja', 'ko', 'nl',
+     |    'pl', 'pt-BR', 'ro', 'ru', 'sv', 'th', 'tr', 'zh-TW', 'zh'
+     */
+
+    'locale'        => 'auto',
+
+    /* -----------------------------------------------------------------
+     |  Theme
+     | -----------------------------------------------------------------
+     |  Supported themes :
+     |    'bootstrap-3', 'bootstrap-4'
+     |  Make your own theme by adding a folder to the views directory and specifying it here.
+     */
+
+    'theme'         => 'bootstrap-4',
+
+    /* -----------------------------------------------------------------
+     |  Route settings
+     | -----------------------------------------------------------------
+     */
+
+    'route'         => [
+        'enabled'    => true,
+
+        'attributes' => [
+            'prefix'     => 'log-viewer',
+
+            'middleware' => \App\Http\Kernel::BACKOFFICE,
+        ],
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Log entries per page
+     | -----------------------------------------------------------------
+     |  This defines how many logs & entries are displayed per page.
+     */
+
+    'per-page'      => 30,
+
+    /* -----------------------------------------------------------------
+     |  Download settings
+     | -----------------------------------------------------------------
+     */
+
+    'download'      => [
+        'prefix'    => 'laravel-',
+
+        'extension' => 'log',
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Menu settings
+     | -----------------------------------------------------------------
+     */
+
+    'menu'  => [
+        'filter-route'  => 'log-viewer::logs.filter',
+
+        'icons-enabled' => true,
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Icons
+     | -----------------------------------------------------------------
+     */
+
+    'icons' =>  [
+        /**
+         * Font awesome >= 4.3
+         * http://fontawesome.io/icons/
+         */
+        'all'       => 'fa fa-fw fa-list',                 // http://fontawesome.io/icon/list/
+        'emergency' => 'fa fa-fw fa-bug',                  // http://fontawesome.io/icon/bug/
+        'alert'     => 'fa fa-fw fa-bullhorn',             // http://fontawesome.io/icon/bullhorn/
+        'critical'  => 'fa fa-fw fa-heartbeat',            // http://fontawesome.io/icon/heartbeat/
+        'error'     => 'fa fa-fw fa-times-circle',         // http://fontawesome.io/icon/times-circle/
+        'warning'   => 'fa fa-fw fa-exclamation-triangle', // http://fontawesome.io/icon/exclamation-triangle/
+        'notice'    => 'fa fa-fw fa-exclamation-circle',   // http://fontawesome.io/icon/exclamation-circle/
+        'info'      => 'fa fa-fw fa-info-circle',          // http://fontawesome.io/icon/info-circle/
+        'debug'     => 'fa fa-fw fa-life-ring',            // http://fontawesome.io/icon/life-ring/
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Colors
+     | -----------------------------------------------------------------
+     */
+
+    'colors' =>  [
+        'levels'    => [
+            'empty'     => '#D1D1D1',
+            'all'       => '#8A8A8A',
+            'emergency' => '#B71C1C',
+            'alert'     => '#D32F2F',
+            'critical'  => '#F44336',
+            'error'     => '#FF5722',
+            'warning'   => '#FF9100',
+            'notice'    => '#4CAF50',
+            'info'      => '#1976D2',
+            'debug'     => '#90CAF9',
+        ],
+    ],
+
+    /* -----------------------------------------------------------------
+     |  Strings to highlight in stack trace
+     | -----------------------------------------------------------------
+     */
+
+    'highlight' => [
+        '^#\d+',
+        '^Stack trace:',
+    ],
+
+];


### PR DESCRIPTION
Guarda con esto, se esta intentando registrar providers en AppServiceProvider cuando debug = true.
Pero eso no funciona si NO se agregan los packages en el array `dont-discover`.

Una solucion a esto seria no instalar en PROD dependencias dev.
Hasta que no hagamos eso, hay q tener cuidado con el registro de deps y las configuraciones de packages.